### PR TITLE
Build own headers to fit twitch requirement

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -17,17 +17,29 @@ class Strategy extends OAuth2Strategy {
 
     super(options, verify);
 
+    this.clientID = options.clientID;
     this.name = "twitch.js";
     this.pem = options.pem;
 
     this._oauth2.setAuthMethod("Bearer");
     this._oauth2.useAuthorizationHeaderforGET(true);
   }
+  
   userProfile(token, done) {
-    this._oauth2.get("https://api.twitch.tv/helix/users", token, function (err, body, res) {
+    let headers = {
+      'Client-ID': this.clientID
+    };
+
+    if (this._oauth2._useAuthorizationHeaderForGET) {
+      headers['Authorization'] = this._oauth2.buildAuthHeader(token)
+      token = null
+    }
+
+    this._oauth2._request("GET", "https://api.twitch.tv/helix/users", headers, "", token, function (err, body, res) {
       if (err) {
         return done(new InternalOAuthError("failed to fetch user profile", err));
       }
+
       try {
         done(null, {
           ...JSON.parse(body).data[0],
@@ -38,6 +50,7 @@ class Strategy extends OAuth2Strategy {
       }
     });
   }
+
   authorizationParams(options) {
     var params = {}
     if (options.forceVerify != undefined) {


### PR DESCRIPTION
Due to [twitch new requirement](https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916). We should send access token (either an app access token or user access token.) and client id on **Every** endpoint